### PR TITLE
Fix for Python 3.x in tests

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -41,7 +41,6 @@ class TestSphinxcontribBlockdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'subdir' / 'index.html').read_text(encoding='utf-8')
-        print source
         self.assertRegexpMatches(source, '<div><img .*? src="\.\./_images/.*?.png" .*?/></div>')
 
     @with_png_app


### PR DESCRIPTION
Removed a print statement that causes this file to break installation with Python 3.x
