### PR TITLE
make depend on docutils > 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 
-requires = ['blockdiag>=1.5.0', 'Sphinx>=0.6']
+requires = ['blockdiag>=1.5.0', 'Sphinx>=0.6', 'docutils>=0.8']
 
 setup(
     name='sphinxcontrib-blockdiag',


### PR DESCRIPTION
with docutils == 0.7, which is the sphynx base dependency, you get this error:

Exception occurred:
  File "/usr/home/bbuser/buildbot.net/bslave/docs/build/sandbox/lib/python2.7/site-packages/blockdiag/utils/rst/directives.py", line 179, in run
    self.add_name(results[0])
AttributeError: 'Blockdiag' object has no attribute 'add_name'
The full traceback has been saved in /tmp/sphinx-err-cJd4N2.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at https://bitbucket.org/birkenfeld/sphinx/issues/. Thanks!
