### PR TITLE
Fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 .coverage
 .tox/
+.mypy_cache/
 bin/
 include/
 lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 language: python
-python: 3.5
-env:
-  matrix:
-    - TOXENV=py26
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py32
-    - TOXENV=py34
-    - TOXENV=py35
-    - TOXENV=sphinx1.0
-    - TOXENV=sphinx1.1
-    - TOXENV=sphinx1.2
-    - TOXENV=blockdiag_dev
-    - TOXENV=coverage
-cache:
-  directories:
-    - $HOME/.cache/pip
-install: pip install docutils tox
+dist: xenial
+cache: pip
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - env: TOXENV=sphinx2.0
+    - env: TOXENV=blockdiag_dev
+    - env: TOXENV=coverage
+install: pip install -U docutils tox
 script: tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,5 +19,5 @@ restructuredtext = 1
 
 [flake8]
 max-line-length=120
-ignore=_
+ignore=W504
 exclude=tests/docs/

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@
 
 from setuptools import setup, find_packages
 
-
-requires = ['blockdiag>=1.5.0', 'Sphinx>=0.6']
+requires = ['blockdiag>=1.5.0', 'Sphinx>=2.0']
 
 setup(
     name='sphinxcontrib-blockdiag',
@@ -24,12 +23,12 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Documentation',
         'Topic :: Documentation :: Sphinx',
         'Topic :: Utilities',

--- a/sphinxcontrib/blockdiag.py
+++ b/sphinxcontrib/blockdiag.py
@@ -26,7 +26,7 @@ from sphinx.util.osutil import ensuredir
 import blockdiag.utils.rst.nodes
 import blockdiag.utils.rst.directives
 from blockdiag.utils.bootstrap import detectfont, Application
-from blockdiag.utils.compat import u, string_types
+from blockdiag.utils.compat import string_types
 from blockdiag.utils.fontmap import FontMap
 from blockdiag.utils.rst.directives import with_blockdiag
 
@@ -85,7 +85,7 @@ def resolve_reference(builder, href):
     if href is None:
         return None
 
-    pattern = re.compile(u("^:ref:`(.+?)`"), re.UNICODE)
+    pattern = re.compile("^:ref:`(.+?)`", re.UNICODE)
     matched = pattern.search(href)
     if matched is None:
         return href

--- a/sphinxcontrib/blockdiag.py
+++ b/sphinxcontrib/blockdiag.py
@@ -20,6 +20,7 @@ import pkg_resources
 from collections import namedtuple
 from docutils import nodes
 from sphinx import addnodes
+from sphinx.util import logging
 from sphinx.util.osutil import ensuredir
 
 import blockdiag.utils.rst.nodes
@@ -31,6 +32,8 @@ from blockdiag.utils.rst.directives import with_blockdiag
 
 # fontconfig; it will be initialized on `builder-inited` event.
 fontmap = None
+
+logger = logging.getLogger(__name__)
 
 
 class blockdiag_node(blockdiag.utils.rst.nodes.blockdiag):
@@ -56,11 +59,7 @@ class blockdiag_node(blockdiag.utils.rst.nodes.blockdiag):
                        fontmap=builder.config.blockdiag_fontmap,
                        format=image_format,
                        transparency=builder.config.blockdiag_transparency)
-        if hasattr(builder, 'imgpath'):  # Sphinx (<= 1.2.x) or HTML writer
-            outputdir = builder.imgpath
-        else:
-            outputdir = ''
-        return posixpath.join(outputdir, self.get_path(**options))
+        return posixpath.join(builder.imgpath, self.get_path(**options))
 
     def get_abspath(self, image_format, builder):
         options = dict(antialias=builder.config.blockdiag_antialias,
@@ -69,13 +68,7 @@ class blockdiag_node(blockdiag.utils.rst.nodes.blockdiag):
                        format=image_format,
                        transparency=builder.config.blockdiag_transparency)
 
-        if hasattr(builder, 'imagedir'):  # Sphinx (>= 1.3.x)
-            outputdir = os.path.join(builder.outdir, builder.imagedir)
-        elif hasattr(builder, 'imgpath'):  # Sphinx (<= 1.2.x) and HTML writer
-            outputdir = os.path.join(builder.outdir, '_images')
-        else:
-            outputdir = builder.outdir
-        path = os.path.join(outputdir, self.get_path(**options))
+        path = os.path.join(builder.outdir, builder.imagedir, self.get_path(**options))
         ensuredir(os.path.dirname(path))
 
         return path
@@ -110,7 +103,7 @@ def resolve_reference(builder, href):
             else:
                 return xref['refuri']
         else:
-            builder.warn('undefined label: %s' % refid)
+            logger.warning('undefined label: %s', refid)
             return None
 
 
@@ -213,13 +206,13 @@ def html_visit_blockdiag(self, node):
 
         msg = ("blockdiag error: UnicodeEncodeError caught "
                "(check your font settings)")
-        self.builder.warn(msg)
+        logger.warning(msg)
         raise nodes.SkipNode
     except Exception as exc:
         if self.builder.config.blockdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+        logger.warning('dot code %r: %s', node['code'], exc)
         raise nodes.SkipNode
 
 
@@ -254,7 +247,7 @@ def get_image_format_for(builder):
 def on_builder_inited(self):
     # show deprecated message
     if self.builder.config.blockdiag_tex_image_format:
-        self.builder.warn('blockdiag_tex_image_format is deprecated. Use blockdiag_latex_image_format.')
+        logger.warning('blockdiag_tex_image_format is deprecated. Use blockdiag_latex_image_format.')
 
     # initialize fontmap
     global fontmap
@@ -288,7 +281,7 @@ def on_doctree_resolved(self, doctree, docname):
         if self.builder.config.blockdiag_debug:
             traceback.print_exc()
 
-        self.builder.warn('blockdiag error: %s' % exc)
+        logger.warning('blockdiag error: %s', exc)
         for node in doctree.traverse(blockdiag_node):
             node.parent.remove(node)
 
@@ -309,7 +302,7 @@ def on_doctree_resolved(self, doctree, docname):
             if self.builder.config.blockdiag_debug:
                 traceback.print_exc()
 
-            self.builder.warn('dot code %r: %s' % (node['code'], str(exc)))
+            logger.warning('dot code %r: %s', node['code'], exc)
             node.parent.remove(node)
 
 

--- a/sphinxcontrib/blockdiag.py
+++ b/sphinxcontrib/blockdiag.py
@@ -255,7 +255,7 @@ def on_builder_inited(self):
     try:
         fontmappath = self.builder.config.blockdiag_fontmap
         fontmap = FontMap(fontmappath)
-    except:
+    except Exception:
         fontmap = FontMap(None)
 
     try:
@@ -267,7 +267,7 @@ def on_builder_inited(self):
             config = namedtuple('Config', 'font')(fontpath)
             fontpath = detectfont(config)
             fontmap.set_default_font(fontpath)
-    except:
+    except Exception:
         pass
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,6 @@
 
 from mock import patch
 from sphinx_testing import with_app
-from blockdiag.utils.compat import u
 
 import sys
 import unittest
@@ -49,7 +48,7 @@ class TestSphinxcontribBlockdiagErrors(unittest.TestCase):
     @with_app(srcdir='tests/docs/basic')
     @patch("sphinxcontrib.blockdiag.blockdiag.drawer.DiagramDraw.draw")
     def test_font_settings_error(self, app, status, warning, draw):
-        draw.side_effect = UnicodeEncodeError("", u(""), 0, 0, "")
+        draw.side_effect = UnicodeEncodeError("", "", 0, 0, "")
         app.builder.build_all()
         self.assertIn('UnicodeEncodeError caught (check your font settings)',
                       warning.getvalue())

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,10 +5,7 @@ from sphinx_testing import with_app
 from blockdiag.utils.compat import u
 
 import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 class TestSphinxcontribBlockdiagErrors(unittest.TestCase):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -37,7 +37,7 @@ class TestSphinxcontribBlockdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'subdir' / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '<div><img .*? src="\.\./_images/.*?.png" .*?/></div>')
+        self.assertRegexpMatches(source, r'<div><img .*? src="../_images/.*?.png" .*?/></div>')
 
     @with_png_app
     def test_width_option_on_png(self, app, status, warning):
@@ -171,7 +171,7 @@ class TestSphinxcontribBlockdiagHTML(unittest.TestCase):
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
         self.assertRegexpMatches(source, ('<div><a class="reference internal image-reference" href="(.*?.png)">'
-                                          '<map name="(map_\d+)">'
+                                          '<map name="(map_\\d+)">'
                                           '<area shape="rect" coords="32.0,20.0,96.0,40.0" '
                                           'href="http://blockdiag.com/"></map>'
                                           '<img .*? src="\\1" usemap="#\\2" .*?/></a></div>'))
@@ -191,7 +191,7 @@ class TestSphinxcontribBlockdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, ('<div><map name="(map_\d+)">'
+        self.assertRegexpMatches(source, ('<div><map name="(map_\\d+)">'
                                           '<area shape="rect" coords="64.0,40.0,192.0,80.0" href="#target"></map>'
                                           '<img .*? src=".*?.png" usemap="#\\1" .*?/></div>'))
 
@@ -210,7 +210,7 @@ class TestSphinxcontribBlockdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, ('<div><map name="(map_\d+)">'
+        self.assertRegexpMatches(source, ('<div><map name="(map_\\d+)">'
                                           '<area shape="rect" coords="64.0,40.0,192.0,80.0" href="#hello-world">'
                                           '</map><img .*? src=".*?.png" usemap="#\\1" .*?/></div>'))
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -2,11 +2,7 @@
 
 from sphinx_testing import with_app
 
-import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 with_png_app = with_app(srcdir='tests/docs/basic',
@@ -373,10 +369,7 @@ class TestSphinxcontribBlockdiagHTML(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'index.html').read_text(encoding='utf-8')
-        if sys.version_info < (3, 0):
-            self.assertNotRegexpMatches(source, '<a xlink:href="#hello-world">\\n\\s*<rect .*?>\\n\\s*</a>')
-        else:
-            self.assertNotRegex(source, '<a xlink:href="#hello-world">\\n\\s*<rect .*?>\\n\\s*</a>')
+        self.assertNotRegex(source, '<a xlink:href="#hello-world">\\n\\s*<rect .*?>\\n\\s*</a>')
         self.assertIn('undefined label: unknown_target', warning.getvalue())
 
     @with_svg_app

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -3,7 +3,6 @@
 import os
 import re
 from sphinx_testing import with_app
-from blockdiag.utils.compat import u
 
 import unittest
 
@@ -14,13 +13,13 @@ with_png_app = with_app(srcdir='tests/docs/basic',
                         buildername='latex',
                         write_docstring=True,
                         confoverrides={
-                            'latex_documents': [('index', 'test.tex', u(''), u('test'), 'manual')],
+                            'latex_documents': [('index', 'test.tex', '', 'test', 'manual')],
                         })
 with_pdf_app = with_app(srcdir='tests/docs/basic',
                         buildername='latex',
                         write_docstring=True,
                         confoverrides={
-                            'latex_documents': [('index', 'test.tex', u(''), u('test'), 'manual')],
+                            'latex_documents': [('index', 'test.tex', '', 'test', 'manual')],
                             'blockdiag_latex_image_format': 'PDF',
                             'blockdiag_fontpath': blockdiag_fontpath,
                         })
@@ -28,7 +27,7 @@ with_oldpdf_app = with_app(srcdir='tests/docs/basic',
                            buildername='latex',
                            write_docstring=True,
                            confoverrides={
-                               'latex_documents': [('index', 'test.tex', u(''), u('test'), 'manual')],
+                               'latex_documents': [('index', 'test.tex', '', 'test', 'manual')],
                                'blockdiag_tex_image_format': 'PDF',
                                'blockdiag_fontpath': blockdiag_fontpath,
                            })

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -5,11 +5,9 @@ import re
 from sphinx_testing import with_app
 from blockdiag.utils.compat import u
 
-import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
+
+CR = "\r?\n"
 
 blockdiag_fontpath = '/usr/share/fonts/truetype/ipafont/ipagp.ttf'
 with_png_app = with_app(srcdir='tests/docs/basic',
@@ -46,10 +44,9 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics{blockdiag-.*?.png}')
+        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{{blockdiag-.*?}.png}')
 
     @unittest.skipUnless(os.path.exists(blockdiag_fontpath), "TrueType font not found")
-    @unittest.skipIf(sys.version_info[:2] == (3, 2), "reportlab does not support python 3.2")
     @with_pdf_app
     def test_build_pdf_image1(self, app, status, warning):
         """
@@ -59,10 +56,9 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics{blockdiag-.*?.pdf}')
+        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{{blockdiag-.*?}.pdf}')
 
     @unittest.skipUnless(os.path.exists(blockdiag_fontpath), "TrueType font not found")
-    @unittest.skipIf(sys.version_info[:2] == (3, 2), "reportlab does not support python 3.2")
     @with_oldpdf_app
     def test_build_pdf_image2(self, app, status, warning):
         """
@@ -72,7 +68,7 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics{blockdiag-.*?.pdf}')
+        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{{blockdiag-.*?}.pdf}')
 
     @with_png_app
     def test_width_option(self, app, status, warning):
@@ -84,7 +80,7 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics\\[width=3cm\\]{blockdiag-.*?.png}')
+        self.assertRegexpMatches(source, r'\\sphinxincludegraphics\[width=3cm\]{{blockdiag-.*?}.png}')
 
     @with_png_app
     def test_height_option(self, app, status, warning):
@@ -96,7 +92,7 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics\\[height=4cm\\]{blockdiag-.*?.png}')
+        self.assertRegexpMatches(source, r'\\sphinxincludegraphics\[height=4cm\]{{blockdiag-.*?}.png}')
 
     @with_png_app
     def test_scale_option(self, app, status, warning):
@@ -108,7 +104,7 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\scalebox{0.500000}{\\\\includegraphics{blockdiag-.*?.png}}')
+        self.assertRegexpMatches(source, r'\\sphinxincludegraphics\[scale=0.5\]{{blockdiag-.*?}.png}')
 
     @with_png_app
     def test_align_option_left(self, app, status, warning):
@@ -120,7 +116,9 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '{\\\\includegraphics{blockdiag-.*?.png}\\\\hfill}')
+        self.assertRegexpMatches(source,
+                                 (r'{\\sphinxincludegraphics{{blockdiag-.*?}.png}'
+                                  r'\\hspace\*{\\fill}}'))
 
     @with_png_app
     def test_align_option_center(self, app, status, warning):
@@ -132,7 +130,10 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '{\\\\hfill\\\\includegraphics{blockdiag-.*?.png}\\\\hfill}')
+        self.assertRegexpMatches(source,
+                                 (r'{\\hspace\*{\\fill}'
+                                  r'\\sphinxincludegraphics{{blockdiag-.*?}.png}'
+                                  r'\\hspace\*{\\fill}}'))
 
     @with_png_app
     def test_align_option_right(self, app, status, warning):
@@ -144,7 +145,9 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '{\\\\hfill\\\\includegraphics{blockdiag-.*?.png}}')
+        self.assertRegexpMatches(source,
+                                 (r'{\\hspace\*{\\fill}'
+                                  r'\\sphinxincludegraphics{{blockdiag-.*?}.png}}'))
 
     @with_png_app
     def test_caption_option(self, app, status, warning):
@@ -156,10 +159,13 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics{blockdiag-.*?.png}')
 
-        figure = re.compile('\\\\begin{figure}\\[htbp\\]\r?\n\\\\centering.*?'
-                            '\\\\caption{hello world}\\\\end{figure}', re.DOTALL)
+        figure = re.compile((r'\\begin{figure}\[htbp\]' + CR +
+                             r'\\centering' + CR +
+                             r'\\capstart' + CR + CR +
+                             r'\\noindent\\sphinxincludegraphics{{blockdiag-.*?}.png}' + CR +
+                             r'\\caption{hello world}\\label{\\detokenize{index:id1}}\\end{figure}'),
+                            re.DOTALL)
         self.assertRegexpMatches(source, figure)
 
     @with_png_app
@@ -173,10 +179,12 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics{blockdiag-.*?.png}')
 
-        figure = re.compile('\\\\begin{figure}\\[htbp\\]\\\\begin{flushleft}.*?'
-                            '\\\\caption{hello world}\\\\end{flushleft}\\\\end{figure}', re.DOTALL)
+        figure = re.compile((r'\\begin{wrapfigure}{l}{0pt}' + CR +
+                             r'\\centering' + CR +
+                             r'\\noindent\\sphinxincludegraphics{{blockdiag-.*?}.png}' + CR +
+                             r'\\caption{hello world}\\label{\\detokenize{index:id1}}\\end{wrapfigure}'),
+                            re.DOTALL)
         self.assertRegexpMatches(source, figure)
 
     @with_png_app
@@ -189,4 +197,4 @@ class TestSphinxcontribBlockdiagLatex(unittest.TestCase):
         """
         app.builder.build_all()
         source = (app.outdir / 'test.tex').read_text(encoding='utf-8')
-        self.assertRegexpMatches(source, '\\\\includegraphics{blockdiag-.*?.png}')
+        self.assertRegexpMatches(source, r'\\sphinxincludegraphics{{blockdiag-.*?}.png}')

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,10 @@
 ## building sphinx docs in separate virtual environments.  Give it a try!
 
 [tox]
-envlist=py26,py27,py32,py33,py34,py35,sphinx1.0,sphinx1.1,sphinx1.2,blockdiag_dev
+envlist = py{35,36,37,38},sphinx2.0,blockdiag_dev
 
 [testenv]
+usedevelop = True
 deps=
     nose
     mock
@@ -20,45 +21,15 @@ commands=
     nosetests
     flake8 setup.py sphinxcontrib/ tests/
 
-[testenv:py26]
-deps=
-    nose
-    mock
-    flake8
-    reportlab < 3.0
-    sphinx-testing >= 0.5.2
-    unittest2
-
-[testenv:py32]
-deps=
-    nose
-    mock
-    flake8
-    Sphinx <= 1.2.9999
-    sphinx-testing >= 0.5.2
-    jinja2 < 2.7
-    pygments <= 1.9999
-
-[testenv:sphinx1.0]
-basepython = python2.7
+[testenv:sphinx2.0]
 deps=
     {[testenv]deps}
-    sphinx <= 1.0.9999
-
-[testenv:sphinx1.1]
-deps=
-    {[testenv]deps}
-    sphinx <= 1.1.9999
-
-[testenv:sphinx1.2]
-deps=
-    {[testenv]deps}
-    sphinx <= 1.2.9999
+    sphinx <= 2.1
 
 [testenv:blockdiag_dev]
 deps=
     {[testenv]deps}
-    hg+https://bitbucket.org/blockdiag/blockdiag
+    git+https://github.com/blockdiag/blockdiag
 
 [testenv:coverage]
 deps=


### PR DESCRIPTION
Python 2.6, 3.4 and Sphinx 1.x has been no longer supported. So we should move to modern ones. So this updates our dependencies and makes CI passed.

Note: This brings breaking changes. So we should release major release after this.