### PR TITLE
introduce blockdiag_image_format configuration

### DIFF
--- a/sphinxcontrib/blockdiag.py
+++ b/sphinxcontrib/blockdiag.py
@@ -219,20 +219,23 @@ def html_depart_blockdiag(self, node):
 
 
 def get_image_format_for(builder):
-    if builder.format in ('html', 'slides'):
-        image_format = builder.config.blockdiag_html_image_format.upper()
-    elif builder.format == 'latex':
-        if builder.config.blockdiag_tex_image_format:
-            image_format = builder.config.blockdiag_tex_image_format.upper()
-        else:
-            image_format = builder.config.blockdiag_latex_image_format.upper()
-    else:
-        image_format = 'PNG'
+    config = builder.config
+    image_format = config.blockdiag_image_format.get(builder.format)
 
-    if image_format.upper() not in ('PNG', 'PDF', 'SVG'):
+    # If an explicit image format is not set, check if the wildcard
+    # entry defines a format.
+    if not image_format:
+        image_format = config.blockdiag_image_format.get('*')
+
+    if not image_format:
+        image_format = 'PNG'  # default image format
+    else:
+        image_format = image_format.upper()
+
+    if image_format not in ('PNG', 'PDF', 'SVG'):
         raise ValueError('unknown format: %s' % image_format)
 
-    if image_format.upper() == 'PDF':
+    if image_format == 'PDF':
         try:
             import reportlab  # NOQA: importing test
         except ImportError:
@@ -303,6 +306,19 @@ def on_doctree_resolved(self, doctree, docname):
             node.parent.remove(node)
 
 
+def default_blockdiag_image_format(config):
+    if config.blockdiag_latex_image_format:
+        latex_image_format = config.blockdiag_latex_image_format
+    else:
+        latex_image_format = config.blockdiag_tex_image_format
+
+    return {
+        'html': config.blockdiag_html_image_format,
+        'slides': config.blockdiag_html_image_format,
+        'latex': latex_image_format,
+    }
+
+
 def setup(app):
     app.add_node(blockdiag_node,
                  html=(html_visit_blockdiag, html_depart_blockdiag))
@@ -312,9 +328,13 @@ def setup(app):
     app.add_config_value('blockdiag_antialias', False, 'html')
     app.add_config_value('blockdiag_transparency', True, 'html')
     app.add_config_value('blockdiag_debug', False, 'html')
-    app.add_config_value('blockdiag_html_image_format', 'PNG', 'html')
-    app.add_config_value('blockdiag_tex_image_format', None, 'html')  # backward compatibility for 1.3.1
-    app.add_config_value('blockdiag_latex_image_format', 'PNG', 'html')
+    app.add_config_value('blockdiag_image_format', default_blockdiag_image_format, 'env')
+
+    # deprecated options
+    app.add_config_value('blockdiag_html_image_format', None, 'html')
+    app.add_config_value('blockdiag_latex_image_format', None, 'latex')
+    app.add_config_value('blockdiag_tex_image_format', None, 'latex')
+
     app.connect("builder-inited", on_builder_inited)
     app.connect("doctree-resolved", on_doctree_resolved)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -18,8 +18,13 @@ class TestSphinxcontribBlockdiagErrors(unittest.TestCase):
         app.builder.build_all()
         self.assertIn('got unexpected token:', warning.getvalue())
 
-    @with_app(srcdir='tests/docs/basic', confoverrides=dict(blockdiag_html_image_format='JPG'))
+    @with_app(srcdir='tests/docs/basic', confoverrides=dict(blockdiag_image_format={'html': 'JPG'}))
     def test_unknown_format_error(self, app, status, warning):
+        app.builder.build_all()
+        self.assertIn('unknown format: JPG', warning.getvalue())
+
+    @with_app(srcdir='tests/docs/basic', confoverrides=dict(blockdiag_html_image_format='JPG'))
+    def test_unknown_format_error_deprecated(self, app, status, warning):
         app.builder.build_all()
         self.assertIn('unknown format: JPG', warning.getvalue())
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -228,8 +228,32 @@ class TestSphinxcontribBlockdiagHTML(unittest.TestCase):
         self.assertIn('undefined label: unknown_target', warning.getvalue())
 
     @with_app(srcdir='tests/docs/basic', copy_srcdir_to_tmpdir=True,
-              write_docstring=True, confoverrides={'blockdiag_html_image_format': 'SVG'})
+              write_docstring=True, confoverrides={'blockdiag_image_format': {'html': 'SVG'}})
     def test_build_svg_image(self, app, status, warning):
+        """
+        .. blockdiag::
+
+           A -> B;
+        """
+        app.builder.build_all()
+        source = (app.outdir / 'index.html').read_text(encoding='utf-8')
+        self.assertRegexpMatches(source, '<div><svg .*?>')
+
+    @with_app(srcdir='tests/docs/basic', copy_srcdir_to_tmpdir=True,
+              write_docstring=True, confoverrides={'blockdiag_image_format': {'*': 'SVG'}})
+    def test_build_svg_image_fallback(self, app, status, warning):
+        """
+        .. blockdiag::
+
+           A -> B;
+        """
+        app.builder.build_all()
+        source = (app.outdir / 'index.html').read_text(encoding='utf-8')
+        self.assertRegexpMatches(source, '<div><svg .*?>')
+
+    @with_app(srcdir='tests/docs/basic', copy_srcdir_to_tmpdir=True,
+              write_docstring=True, confoverrides={'blockdiag_html_image_format': 'SVG'})
+    def test_build_svg_image_deprecated(self, app, status, warning):
         """
         .. blockdiag::
 


### PR DESCRIPTION
This commit adds support for a generic `blockdiag_image_format`, which could be applied for any type of builder. The goal is to provide users a means to configure non-standard builder types (which may use this extension) to hint at what type of image format they desire.

----

If these changes eventually moved to a state where they are merged, I can apply similar changes to the other sphinxcontrib extension of the blockdiag group.